### PR TITLE
Add: Support for keyPair as wallet adapter

### DIFF
--- a/packages/stream/src/stream.ts
+++ b/packages/stream/src/stream.ts
@@ -1,811 +1,945 @@
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
-import { Commitment, Connection, ConnectionConfig, Keypair, PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
-import { ZEBEC_PROGRAM_ID, RPC_ENDPOINTS, WITHDRAW_SOL_STRING, WITHDRAW_TOKEN_STRING, SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID, FEE_ADDRESS, _TOKEN_PROGRAM_ID, SYSTEM_RENT, A_TOKEN } from "./constants";
-import * as INSTRUCTIONS from './instructions'
-import { DepositWithdrawSol, InitNativeStream, PauseResumeCancelNativeStream, SignAndConfirm, StreamTransactionResponse, WithdrawNativeStream } from "./types";
-
+import {
+  Commitment,
+  Connection,
+  ConnectionConfig,
+  Keypair,
+  PublicKey,
+  Transaction,
+} from "@solana/web3.js";
+import {
+  ZEBEC_PROGRAM_ID,
+  RPC_ENDPOINTS,
+  WITHDRAW_SOL_STRING,
+  WITHDRAW_TOKEN_STRING,
+  SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
+  FEE_ADDRESS,
+  _TOKEN_PROGRAM_ID,
+  SYSTEM_RENT,
+  A_TOKEN,
+} from "./constants";
+import * as INSTRUCTIONS from "./instructions";
+import {
+  DepositWithdrawSol,
+  InitNativeStream,
+  PauseResumeCancelNativeStream,
+  SignAndConfirm,
+  StreamTransactionResponse,
+  WithdrawNativeStream,
+} from "./types";
 
 class ZebecStream {
-    protected _connection: Connection;
-    protected _programId: PublicKey = new PublicKey(ZEBEC_PROGRAM_ID);
-    protected _commitment: Commitment | ConnectionConfig | undefined;
-    protected walletProvider: any
+  protected _connection: Connection;
+  protected _programId: PublicKey = new PublicKey(ZEBEC_PROGRAM_ID);
+  protected _commitment: Commitment | ConnectionConfig | undefined;
+  protected walletProvider: any;
 
-    constructor (
-        walletProvider: any,
-        rpcUrl: string,
-        commitment: Commitment | string
-    ) {
-        this.walletProvider = walletProvider;
-        this._connection = new Connection(rpcUrl, this._commitment);
-        this._commitment = commitment as Commitment;
+  constructor(
+    walletProvider: any,
+    rpcUrl: string,
+    commitment: Commitment | string
+  ) {
+    this.walletProvider = walletProvider;
+    this._connection = new Connection(rpcUrl, this._commitment);
+    this._commitment = commitment as Commitment;
+  }
+
+  protected async _signAndConfirm(
+    tx: Transaction,
+    signer: Array<Keypair> | [] = [],
+    commitment: Commitment | undefined = "finalized"
+  ): Promise<SignAndConfirm> {
+    let signature: any;
+
+    if (this.walletProvider instanceof Keypair) {
+      tx.sign(this.walletProvider, ...signer);
+      signature = await this._connection.sendRawTransaction(tx.serialize());
+      // console.log("tx signed by keypair", signature);
+    } else {
+      const signed = await this.walletProvider.signTransaction(tx);
+      signature = await this._connection.sendRawTransaction(signed.serialize());
     }
 
-    protected async _signAndConfirm(tx: Transaction, commitment: Commitment | undefined = "confirmed"): Promise<SignAndConfirm> {
-        const signed = await this.walletProvider.signTransaction(tx);
-        const signature = await this._connection.sendRawTransaction(signed.serialize());
-        await this._connection.confirmTransaction(signature, commitment);
+    await this._connection.confirmTransaction(signature, commitment);
+    return {
+      transactionHash: signature,
+    };
+  }
 
-        return {
-            transactionHash: signature
-        }
-    }
-
-    protected async _findZebecWalletAccount(walletAddress: PublicKey): Promise<[PublicKey, number]> {
-        return await PublicKey.findProgramAddress(
-            [walletAddress.toBuffer()],
-            this._programId
-        )
-    }
-
+  protected async _findZebecWalletAccount(
+    walletAddress: PublicKey
+  ): Promise<[PublicKey, number]> {
+    return await PublicKey.findProgramAddress(
+      [walletAddress.toBuffer()],
+      this._programId
+    );
+  }
 }
 
 export class NativeStream extends ZebecStream {
-    constructor(
-        walletProvider: any,
-        rpcUrl: string = RPC_ENDPOINTS.DEFAULT,
-        commitment: Commitment |  undefined = "confirmed"
-    ) {
-        super(walletProvider, rpcUrl, commitment);
-        // console.log("Native Stream Initialized!", walletProvider, rpcUrl);
+  constructor(
+    walletProvider: any,
+    rpcUrl: string = RPC_ENDPOINTS.DEFAULT,
+    commitment: Commitment | undefined = "finalized"
+  ) {
+    super(walletProvider, rpcUrl, commitment);
+  }
+
+  protected async _findWithDrawEscrowAccount(
+    walletAddress: PublicKey
+  ): Promise<[PublicKey, number]> {
+    return await PublicKey.findProgramAddress(
+      [Buffer.from(WITHDRAW_SOL_STRING), walletAddress.toBuffer()],
+      this._programId
+    );
+  }
+
+  async deposit(data: DepositWithdrawSol): Promise<StreamTransactionResponse> {
+    const { sender, amount } = data;
+
+    // console.log("deposit solana to Zebec Wallet started with: ", data);
+
+    const senderAddress = new PublicKey(sender);
+    const [zebecWalletAddress, _] = await this._findZebecWalletAccount(
+      senderAddress
+    );
+
+    const ix = await INSTRUCTIONS.createDepositSolInstruction(
+      senderAddress,
+      zebecWalletAddress,
+      amount,
+      this._programId
+    );
+
+    let tx = new Transaction().add({ ...ix });
+    const recentHash = await this._connection.getRecentBlockhash();
+
+    try {
+      tx.recentBlockhash = recentHash.blockhash;
+      tx.feePayer = this.walletProvider.publicKey;
+
+      // console.log("transaction ix after adding properties: ", tx);
+
+      const res = await this._signAndConfirm(tx);
+
+      return {
+        status: "success",
+        message: "deposit successful",
+        data: {
+          ...res,
+        },
+      };
+    } catch (e) {
+      return {
+        status: "error",
+        message: e,
+        data: null,
+      };
     }
+  }
 
-    protected async _findWithDrawEscrowAccount(walletAddress: PublicKey): Promise<[PublicKey, number]> {
-        
-        return await PublicKey.findProgramAddress(
-            [Buffer.from(WITHDRAW_SOL_STRING), walletAddress.toBuffer()],
-            this._programId
-        )
+  async withdrawDepositedSol(
+    data: DepositWithdrawSol
+  ): Promise<StreamTransactionResponse> {
+    const { sender, amount } = data;
+    // console.log("withdraw solana from Zebec Wallet started with: ", data);
+
+    const senderAddress = new PublicKey(sender);
+    const [zebecWalletAddress, __] = await this._findZebecWalletAccount(
+      senderAddress
+    );
+    const [withdrawEscrow, _] = await this._findWithDrawEscrowAccount(
+      senderAddress
+    );
+
+    const ix = await INSTRUCTIONS.createWithdrawDepositedSolInstruction(
+      senderAddress,
+      zebecWalletAddress,
+      withdrawEscrow,
+      amount,
+      this._programId
+    );
+
+    let tx = new Transaction().add({ ...ix });
+    const recentHash = await this._connection.getRecentBlockhash();
+
+    try {
+      tx.recentBlockhash = recentHash.blockhash;
+      tx.feePayer = this.walletProvider.publicKey;
+
+      // console.log("transaction ix after adding properties: ", tx);
+
+      const res = await this._signAndConfirm(tx);
+
+      // console.log("response from sign and confirm: ", res);
+
+      return {
+        status: "success",
+        message: "withdraw successful",
+        data: {
+          ...res,
+        },
+      };
+    } catch (e) {
+      return {
+        status: "error",
+        message: e,
+        data: null,
+      };
     }
+  }
 
-    async deposit(data: DepositWithdrawSol): Promise<StreamTransactionResponse> {
-        const { sender, amount } = data;
+  async init(data: InitNativeStream): Promise<StreamTransactionResponse> {
+    const { sender, receiver, start_time, end_time, amount } = data;
+    // console.log("init solana stream data: ", data);
 
-        // console.log("deposit solana to Zebec Wallet started with: ", data);
+    const senderAddress = new PublicKey(sender);
+    const recipientAddress = new PublicKey(receiver);
+    const [withdraw_escrow, _] = <[PublicKey, number]>(
+      await this._findWithDrawEscrowAccount(senderAddress)
+    );
 
-        const senderAddress = new PublicKey(sender);
-        const [zebecWalletAddress, _] = await this._findZebecWalletAccount(senderAddress);
+    const tx_escrow = new Keypair();
 
-        const ix = await INSTRUCTIONS.createDepositSolInstruction(
-            senderAddress,
-            zebecWalletAddress,
-            amount,
-            this._programId
-        )
+    const ix = await INSTRUCTIONS.createInitSolStreamInstruction(
+      senderAddress,
+      recipientAddress,
+      tx_escrow,
+      withdraw_escrow,
+      this._programId,
+      start_time,
+      end_time,
+      amount
+    );
 
-        let tx = new Transaction().add({...ix});
-        const recentHash = await this._connection.getRecentBlockhash();
+    let tx = new Transaction().add({ ...ix });
 
-        try {
-            tx.recentBlockhash = recentHash.blockhash;
-            tx.feePayer = this.walletProvider.publicKey;
-            
-            // console.log("transaction ix after adding properties: ", tx);
-    
-            const res = await this._signAndConfirm(tx);
+    const recentHash = await this._connection.getRecentBlockhash();
 
-            // console.log("response from sign and confirm: ", res);
-    
-            return {
-                status: "success",
-                message: "deposit successful",
-                data: {
-                    ...res
-                }
-            }
-        } catch(e) {
-            return {
-                status: "error",
-                message: e,
-                data: null
-            }
-        }
+    try {
+      tx.recentBlockhash = recentHash.blockhash;
+      tx.feePayer = this.walletProvider.publicKey;
+      tx.partialSign(tx_escrow);
+
+      // console.log("transaction ix after adding properties: ", tx);
+
+      const res = await this._signAndConfirm(tx, [tx_escrow]);
+
+      // console.log("response from sign and confirm: ", res);
+
+      return {
+        status: "success",
+        message: "stream started successfully",
+        data: {
+          pda: tx_escrow.publicKey.toBase58(),
+          ...res,
+        },
+      };
+    } catch (e) {
+      return {
+        status: "error",
+        message: e,
+        data: null,
+      };
     }
+  }
 
-    async withdrawDepositedSol(data: DepositWithdrawSol): Promise<StreamTransactionResponse> {
-        const { sender, amount } = data;
-        // console.log("withdraw solana from Zebec Wallet started with: ", data);
+  async pause(
+    data: PauseResumeCancelNativeStream
+  ): Promise<StreamTransactionResponse> {
+    const { sender, receiver, pda } = data;
+    // console.log("pause solana stream data: ", data);
 
-        const senderAddress = new PublicKey(sender);
-        const [zebecWalletAddress, __] = await this._findZebecWalletAccount(senderAddress);
-        const [withdrawEscrow, _] = await this._findWithDrawEscrowAccount(senderAddress);
+    const senderAddress = new PublicKey(sender);
+    const recipientAddress = new PublicKey(receiver);
+    const escrowAddress = new PublicKey(pda);
 
-        const ix = await INSTRUCTIONS.createWithdrawDepositedSolInstruction(
-            senderAddress,
-            zebecWalletAddress,
-            withdrawEscrow,
-            amount,
-            this._programId
-        )
+    const ix = await INSTRUCTIONS.createPauseSolStreamInstruction(
+      senderAddress,
+      recipientAddress,
+      escrowAddress,
+      this._programId
+    );
 
-        let tx = new Transaction().add({...ix});
-        const recentHash = await this._connection.getRecentBlockhash();
+    let tx = new Transaction().add({ ...ix });
+    let recentHash = await this._connection.getRecentBlockhash();
 
-        try {
-            tx.recentBlockhash = recentHash.blockhash;
-            tx.feePayer = this.walletProvider.publicKey;
-            
-            // console.log("transaction ix after adding properties: ", tx);
-    
-            const res = await this._signAndConfirm(tx);
+    try {
+      tx.recentBlockhash = recentHash.blockhash;
+      tx.feePayer = this.walletProvider.publicKey;
 
-            // console.log("response from sign and confirm: ", res);
-    
-            return {
-                status: "success",
-                message: "withdraw successful",
-                data: {
-                    ...res
-                }
-            }
-        } catch(e) {
-            return {
-                status: "error",
-                message: e,
-                data: null
-            }
-        }
+      // console.log("transaction ix after adding properties: ", tx);
 
+      const res = await this._signAndConfirm(tx);
 
+      // console.log("response from sign and confirm: ", res);
+
+      return {
+        status: "success",
+        message: "stream paused",
+        data: {
+          ...res,
+        },
+      };
+    } catch (e) {
+      return {
+        status: "error",
+        message: e,
+        data: null,
+      };
     }
+  }
 
-    async init(data: InitNativeStream): Promise<StreamTransactionResponse> {
-        const { sender, receiver, start_time, end_time, amount } = data;
-        // console.log("init solana stream data: ", data);
-        
-        const senderAddress = new PublicKey(sender);
-        const recipientAddress = new PublicKey(receiver)
-        const [withdraw_escrow, _] = <[PublicKey, number]>await this._findWithDrawEscrowAccount(senderAddress);
+  async resume(
+    data: PauseResumeCancelNativeStream
+  ): Promise<StreamTransactionResponse> {
+    const { sender, receiver, pda } = data;
+    // console.log("resume solana stream data: ", data);
 
-        const tx_escrow = new Keypair();
+    const senderAddress = new PublicKey(sender);
+    const recipientAddress = new PublicKey(receiver);
+    const escrowAddress = new PublicKey(pda);
 
-        const ix = await INSTRUCTIONS.createInitSolStreamInstruction(
-            senderAddress,
-            recipientAddress,
-            tx_escrow,
-            withdraw_escrow,
-            this._programId,
-            start_time,
-            end_time,
-            amount
-        )
+    const ix = await INSTRUCTIONS.createResumeSolStreamInstruction(
+      senderAddress,
+      recipientAddress,
+      escrowAddress,
+      this._programId
+    );
 
-        let tx = new Transaction().add({...ix})
+    let tx = new Transaction().add({ ...ix });
+    const recentHash = await this._connection.getRecentBlockhash();
 
-        const recentHash = await this._connection.getRecentBlockhash()
+    try {
+      tx.recentBlockhash = recentHash.blockhash;
+      tx.feePayer = this.walletProvider.publicKey;
 
-        try {
-            tx.recentBlockhash = recentHash.blockhash;
-            tx.feePayer = this.walletProvider.publicKey;
-            tx.partialSign(tx_escrow);
-            
-            // console.log("transaction ix after adding properties: ", tx);
-    
-            const res = await this._signAndConfirm(tx);
+      // console.log("transaction ix after adding properties: ", tx);
 
-            // console.log("response from sign and confirm: ", res);
-    
-            return {
-                status: "success",
-                message: "stream started successfully",
-                data: {
-                    pda: tx_escrow.publicKey.toBase58(), 
-                    ...res
-                }
-            }
-        } catch(e) {
-            return {
-                status: "error",
-                message: e,
-                data: null
-            }
-        }
+      const res = await this._signAndConfirm(tx);
+
+      // console.log("response from sign and confirm: ", res);
+
+      return {
+        status: "success",
+        message: "stream resumed",
+        data: {
+          ...res,
+        },
+      };
+    } catch (e) {
+      return {
+        status: "error",
+        message: e,
+        data: null,
+      };
     }
+  }
 
-    async pause(data: PauseResumeCancelNativeStream): Promise<StreamTransactionResponse> {
-        const { sender, receiver, pda } = data;
-        // console.log("pause solana stream data: ", data);
+  async cancel(
+    data: PauseResumeCancelNativeStream
+  ): Promise<StreamTransactionResponse> {
+    const { sender, receiver, pda } = data;
+    // console.log("cancel solana stream data: ", data);
 
+    const senderAddress = new PublicKey(sender);
+    const recipientAddress = new PublicKey(receiver);
+    const escrowAddress = new PublicKey(pda);
 
-        const senderAddress = new PublicKey(sender);
-        const recipientAddress = new PublicKey(receiver);
-        const escrowAddress = new PublicKey(pda);
+    const [zebecWallet, __] = await this._findZebecWalletAccount(senderAddress);
+    const [withdrawEscrow, _] = await this._findWithDrawEscrowAccount(
+      senderAddress
+    );
 
-        const ix = await INSTRUCTIONS.createPauseSolStreamInstruction(
-            senderAddress,
-            recipientAddress,
-            escrowAddress,
-            this._programId
-        )
+    const ix = await INSTRUCTIONS.createCancelSolStreamInstruction(
+      senderAddress,
+      recipientAddress,
+      escrowAddress,
+      zebecWallet,
+      withdrawEscrow,
+      this._programId
+    );
 
-        let tx = new Transaction().add({...ix});
-        let recentHash = await this._connection.getRecentBlockhash();
+    let tx = new Transaction().add({ ...ix });
 
-        try {
-            tx.recentBlockhash = recentHash.blockhash;
-            tx.feePayer = this.walletProvider.publicKey;
-            
-            // console.log("transaction ix after adding properties: ", tx);
-    
-            const res = await this._signAndConfirm(tx);
+    const recentHash = await this._connection.getRecentBlockhash();
 
-            // console.log("response from sign and confirm: ", res);
-    
-            return {
-                status: "success",
-                message: "stream paused",
-                data: { 
-                    ...res
-                }
-            }
-        } catch(e) {
-            return {
-                status: "error",
-                message: e,
-                data: null
-            }
-        }
+    try {
+      tx.recentBlockhash = recentHash.blockhash;
+      tx.feePayer = this.walletProvider.publicKey;
+
+      // console.log("transaction ix after adding properties: ", tx);
+
+      const res = await this._signAndConfirm(tx);
+
+      // console.log("response from sign and confirm: ", res);
+
+      return {
+        status: "success",
+        message: "stream canceled",
+        data: {
+          ...res,
+        },
+      };
+    } catch (e) {
+      return {
+        status: "error",
+        message: e,
+        data: null,
+      };
     }
+  }
 
-    async resume(data: PauseResumeCancelNativeStream): Promise<StreamTransactionResponse> {
-        const { sender, receiver, pda } = data;
-        // console.log("resume solana stream data: ", data);
-        
-        const senderAddress = new PublicKey(sender);
-        const recipientAddress = new PublicKey(receiver);
-        const escrowAddress = new PublicKey(pda);
+  async withdraw(
+    data: WithdrawNativeStream
+  ): Promise<StreamTransactionResponse> {
+    const { sender, amount, receiver, pda } = data;
+    // console.log("withdraw solana stream data: ", data);
 
-        const ix = await INSTRUCTIONS.createResumeSolStreamInstruction(
-            senderAddress,
-            recipientAddress,
-            escrowAddress,
-            this._programId
-        )
+    const senderAddress = new PublicKey(sender);
+    const recipientAddress =
+      receiver instanceof Keypair
+        ? new PublicKey(receiver.publicKey)
+        : new PublicKey(receiver);
 
-        let tx = new Transaction().add({...ix})
-        const recentHash = await this._connection.getRecentBlockhash()
-        
-        try {
-            tx.recentBlockhash = recentHash.blockhash;
-            tx.feePayer = this.walletProvider.publicKey;
-            
-            // console.log("transaction ix after adding properties: ", tx);
-    
-            const res = await this._signAndConfirm(tx);
+    const escrowAddress = new PublicKey(pda);
+    const [zebecWalletAddress, _] = await this._findZebecWalletAccount(
+      senderAddress
+    );
+    const [withdrawEscrowAddress, __] = await this._findWithDrawEscrowAccount(
+      senderAddress
+    );
 
-            // console.log("response from sign and confirm: ", res);
-    
-            return {
-                status: "success",
-                message: "stream resumed",
-                data: { 
-                    ...res
-                }
-            }
-        } catch(e) {
-            return {
-                status: "error",
-                message: e,
-                data: null
-            }
-        }
+    const ix = await INSTRUCTIONS.createWithdrawSolStreamInstruction(
+      senderAddress,
+      recipientAddress,
+      escrowAddress,
+      zebecWalletAddress,
+      withdrawEscrowAddress,
+      amount,
+      this._programId
+    );
+
+    let tx = new Transaction().add({ ...ix });
+
+    const recentHash = await this._connection.getRecentBlockhash();
+
+    try {
+      tx.recentBlockhash = recentHash.blockhash;
+      tx.feePayer = this.walletProvider.publicKey;
+
+      let res;
+      // console.log("transaction ix after adding properties: ", tx);
+      if (receiver instanceof Keypair) {
+        res = await this._signAndConfirm(tx, [receiver]);
+      } else {
+        res = await this._signAndConfirm(tx);
+      }
+
+      // console.log("response from sign and confirm: ", res);
+
+      return {
+        status: "success",
+        message: "withdraw successful",
+        data: {
+          ...res,
+        },
+      };
+    } catch (e) {
+      return {
+        status: "error",
+        message: e,
+        data: null,
+      };
     }
-
-    async cancel(data: PauseResumeCancelNativeStream): Promise<StreamTransactionResponse> {
-        const { sender, receiver, pda} = data;
-        // console.log("cancel solana stream data: ", data);
-
-        const senderAddress = new PublicKey(sender);
-        const recipientAddress = new PublicKey(receiver);
-        const escrowAddress = new PublicKey(pda);
-
-        const [zebecWallet, __] = await this._findZebecWalletAccount(senderAddress);
-        const [withdrawEscrow, _] = await this._findWithDrawEscrowAccount(senderAddress);
-
-        const ix = await INSTRUCTIONS.createCancelSolStreamInstruction(
-            senderAddress,
-            recipientAddress,
-            escrowAddress,
-            zebecWallet,
-            withdrawEscrow,
-            this._programId
-        )
-
-        let tx = new Transaction().add({...ix});
-
-        const recentHash = await this._connection.getRecentBlockhash()
-        
-        try {
-            tx.recentBlockhash = recentHash.blockhash;
-            tx.feePayer = this.walletProvider.publicKey;
-            
-            // console.log("transaction ix after adding properties: ", tx);
-    
-            const res = await this._signAndConfirm(tx);
-
-            // console.log("response from sign and confirm: ", res);
-    
-            return {
-                status: "success",
-                message: "stream canceled",
-                data: { 
-                    ...res
-                }
-            }
-        } catch(e) {
-            return {
-                status: "error",
-                message: e,
-                data: null
-            }
-        }
-    }
-
-    async withdraw(data: WithdrawNativeStream): Promise<StreamTransactionResponse> {
-        const { sender, amount, receiver, pda } = data;
-        // console.log("withdraw solana stream data: ", data);
-
-        const senderAddress = new PublicKey(sender);
-        const recipientAddress = new PublicKey(receiver);
-        const escrowAddress = new PublicKey(pda);
-
-        const [zebecWalletAddress, _] = await this._findZebecWalletAccount(senderAddress);
-        const [withdrawEscrowAddress, __] = await this._findWithDrawEscrowAccount(senderAddress);
-
-        const ix = await INSTRUCTIONS.createWithdrawSolStreamInstruction(
-            senderAddress,
-            recipientAddress,
-            escrowAddress,
-            zebecWalletAddress,
-            withdrawEscrowAddress,
-            amount,
-            this._programId
-        )
-
-        let tx = new Transaction().add({...ix});
-
-        const recentHash = await this._connection.getRecentBlockhash()
-        
-        try {
-            tx.recentBlockhash = recentHash.blockhash;
-            tx.feePayer = this.walletProvider.publicKey;
-            
-            // console.log("transaction ix after adding properties: ", tx);
-    
-            const res = await this._signAndConfirm(tx);
-
-            // console.log("response from sign and confirm: ", res);
-    
-            return {
-                status: "success",
-                message: "withdraw successful",
-                data: { 
-                    ...res
-                }
-            }
-        } catch(e) {
-            return {
-                status: "error",
-                message: e,
-                data: null
-            }
-        }
-    }
+  }
 }
 
-
 export class TokenStream extends ZebecStream {
-    constructor(
-        walletProvider: any,
-        rpcUrl: string = RPC_ENDPOINTS.DEFAULT,
-        commitment: Commitment |  undefined = "confirmed"
-    ) {
-        super(walletProvider, rpcUrl, commitment);
-        // console.log("Token Stream Initialized!", walletProvider, rpcUrl);
+  constructor(
+    walletProvider: any,
+    rpcUrl: string = RPC_ENDPOINTS.DEFAULT,
+    commitment: Commitment | undefined = "finalized"
+  ) {
+    super(walletProvider, rpcUrl, commitment);
+    // console.log("Token Stream Initialized!", walletProvider, rpcUrl);
+  }
+
+  protected async _findWithDrawEscrowAccount(
+    walletAddress: PublicKey,
+    tokenMintAddress: PublicKey
+  ): Promise<[PublicKey, number]> {
+    return await PublicKey.findProgramAddress(
+      [
+        Buffer.from(WITHDRAW_TOKEN_STRING),
+        walletAddress.toBuffer(),
+        tokenMintAddress.toBuffer(),
+      ],
+      this._programId
+    );
+  }
+
+  protected async _findAssociatedTokenAddress(
+    walletAddress: PublicKey,
+    tokenMintAddress: PublicKey
+  ): Promise<PublicKey> {
+    return (
+      await PublicKey.findProgramAddress(
+        [
+          walletAddress.toBuffer(),
+          TOKEN_PROGRAM_ID.toBuffer(),
+          tokenMintAddress.toBuffer(),
+        ],
+        new PublicKey(SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID)
+      )
+    )[0];
+  }
+
+  public async init(data: any): Promise<any> {
+    const { sender, receiver, token, start_time, end_time, amount } = data;
+    // console.log("sender token stream data: ", data);
+
+    const senderAddress = new PublicKey(sender);
+    const recipientAddress = new PublicKey(receiver);
+    const tokenMintAddress = new PublicKey(token);
+
+    const [withdrawEscrowAddress, _] = await this._findWithDrawEscrowAccount(
+      senderAddress,
+      tokenMintAddress
+    );
+
+    const escrowAddress = new Keypair();
+
+    const ix = await INSTRUCTIONS.createInitMultiTokenStreamInstruction(
+      senderAddress,
+      recipientAddress,
+      escrowAddress.publicKey,
+      withdrawEscrowAddress,
+      this._programId,
+      tokenMintAddress,
+      start_time,
+      end_time,
+      amount
+    );
+
+    let tx = new Transaction().add({ ...ix });
+    const recentHash = await this._connection.getRecentBlockhash();
+
+    try {
+      tx.recentBlockhash = recentHash.blockhash;
+      tx.feePayer = this.walletProvider.publicKey;
+      tx.partialSign(escrowAddress);
+
+      // console.log("transaction ix after adding properties: ", tx);
+
+      const res = await this._signAndConfirm(tx, [escrowAddress]);
+
+      // console.log("response from sign and confirm: ", res);
+
+      return {
+        status: "success",
+        message: "initiated token stream",
+        data: {
+          pda: escrowAddress.publicKey.toBase58(),
+          ...res,
+        },
+      };
+    } catch (e) {
+      return {
+        status: "error",
+        message: e,
+        data: null,
+      };
     }
+  }
 
-    protected async _findWithDrawEscrowAccount(walletAddress: PublicKey, tokenMintAddress: PublicKey): Promise<[PublicKey, number]> {
-        
-        return await PublicKey.findProgramAddress(
-            [Buffer.from(WITHDRAW_TOKEN_STRING), walletAddress.toBuffer(), tokenMintAddress.toBuffer()],
-            this._programId
-        )
+  public async pause(data: any): Promise<any> {
+    const { sender, receiver, pda } = data;
+
+    // console.log("pause token stream data: ", data);
+
+    const senderAddress = new PublicKey(sender);
+    const recipientAddress = new PublicKey(receiver);
+    const escrowAddress = new PublicKey(pda);
+    // const tokenMintAddress = new PublicKey(token);
+
+    const ix = await INSTRUCTIONS.createPauseMultiTokenStreamInstruction(
+      senderAddress,
+      recipientAddress,
+      escrowAddress,
+      this._programId
+    );
+
+    let tx = new Transaction().add({ ...ix });
+    const recentHash = await this._connection.getRecentBlockhash();
+
+    try {
+      tx.recentBlockhash = recentHash.blockhash;
+      tx.feePayer = this.walletProvider.publicKey;
+
+      // console.log("transaction ix after adding properties: ", tx);
+
+      const res = await this._signAndConfirm(tx);
+
+      // console.log("response from sign and confirm: ", res);
+
+      return {
+        status: "success",
+        message: "paused token stream.",
+        data: {
+          ...res,
+        },
+      };
+    } catch (e) {
+      return {
+        status: "error",
+        message: e,
+        data: null,
+      };
     }
+  }
 
-    protected async _findAssociatedTokenAddress(walletAddress: PublicKey, tokenMintAddress: PublicKey): Promise<PublicKey> {
-        return (await PublicKey.findProgramAddress(
-            [ walletAddress.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), tokenMintAddress.toBuffer(),],
-            new PublicKey(SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID)
-        ))[0];
+  public async resume(data: any): Promise<any> {
+    const { sender, receiver, pda } = data;
+
+    // console.log("resume token stream data: ", data);
+
+    const senderAddress = new PublicKey(sender);
+    const recipientAddress = new PublicKey(receiver);
+    const escrowAddress = new PublicKey(pda);
+
+    const ix = await INSTRUCTIONS.createResumeMultiTokenStreamInstruction(
+      senderAddress,
+      recipientAddress,
+      escrowAddress,
+      this._programId
+    );
+
+    let tx = new Transaction().add({ ...ix });
+    const recentHash = await this._connection.getRecentBlockhash();
+
+    try {
+      tx.recentBlockhash = recentHash.blockhash;
+      tx.feePayer = this.walletProvider.publicKey;
+
+      // console.log("transaction ix after adding properties: ", tx);
+
+      const res = await this._signAndConfirm(tx);
+
+      // console.log("response from sign and confirm: ", res);
+
+      return {
+        status: "success",
+        message: "resumed token stream.",
+        data: {
+          ...res,
+        },
+      };
+    } catch (e) {
+      return {
+        status: "error",
+        message: e,
+        data: null,
+      };
     }
+  }
 
-    public async init(data: any): Promise<any> {
-        const { sender, receiver, token, start_time, end_time, amount } = data;
-        // console.log("sender token stream data: ", data);
+  public async cancel(data: any): Promise<any> {
+    const { sender, receiver, token, pda } = data;
 
-        const senderAddress = new PublicKey(sender);
-        const recipientAddress = new PublicKey(receiver);
-        const tokenMintAddress = new PublicKey(token);
+    // console.log("cancel token stream data: ", data);
 
-        const [withdrawEscrowAddress, _] = await this._findWithDrawEscrowAccount(senderAddress, tokenMintAddress);
+    const senderAddress = new PublicKey(sender);
+    const recipientAddress = new PublicKey(receiver);
+    const tokenMintAddress = new PublicKey(token);
+    const escrowAddress = new PublicKey(pda);
 
-        const escrowAddress = new Keypair();
+    const [withdrawEscrowAddress, _] = await this._findWithDrawEscrowAccount(
+      senderAddress,
+      tokenMintAddress
+    );
+    const [zebecWalletAddress, __] = await this._findZebecWalletAccount(
+      senderAddress
+    );
 
-        const ix = await INSTRUCTIONS.createInitMultiTokenStreamInstruction(
-            senderAddress,
-            recipientAddress,
-            escrowAddress.publicKey,
-            withdrawEscrowAddress,
-            this._programId,
-            tokenMintAddress,
-            start_time,
-            end_time,
-            amount
-        )
+    const recipientAssociatedTokenAddress =
+      await this._findAssociatedTokenAddress(
+        recipientAddress,
+        tokenMintAddress
+      );
+    const zebecWalletAssociatedTokenAddress =
+      await this._findAssociatedTokenAddress(
+        zebecWalletAddress,
+        tokenMintAddress
+      );
+    const feeAssociatedTokenAddress = await this._findAssociatedTokenAddress(
+      new PublicKey(FEE_ADDRESS),
+      tokenMintAddress
+    );
 
-        let tx = new Transaction().add({...ix});
-        const recentHash = await this._connection.getRecentBlockhash();
+    const ix = await INSTRUCTIONS.createCancelMultiTokenStreamInstruction(
+      senderAddress,
+      recipientAddress,
+      tokenMintAddress,
+      zebecWalletAddress,
+      escrowAddress,
+      withdrawEscrowAddress,
+      this._programId,
+      recipientAssociatedTokenAddress,
+      zebecWalletAssociatedTokenAddress,
+      feeAssociatedTokenAddress
+    );
 
-        try {
-            tx.recentBlockhash = recentHash.blockhash;
-            tx.feePayer = this.walletProvider.publicKey;
-            tx.partialSign(escrowAddress);
+    let tx = new Transaction().add({ ...ix });
+    const recentHash = await this._connection.getRecentBlockhash();
 
-            // console.log("transaction ix after adding properties: ", tx);
-    
-            const res = await this._signAndConfirm(tx);
+    try {
+      tx.recentBlockhash = recentHash.blockhash;
+      tx.feePayer = this.walletProvider.publicKey;
 
-            // console.log("response from sign and confirm: ", res);
-    
-            return {
-                status: "success",
-                message: "initiated token stream",
-                data: {
-                    pda: escrowAddress.publicKey.toBase58(),
-                    ...res
-                }
-            }
-        } catch(e) {
-            return {
-                status: "error",
-                message: e,
-                data: null
-            }
-        }
+      // console.log("transaction ix after adding properties: ", tx);
+
+      const res = await this._signAndConfirm(tx);
+
+      // console.log("response from sign and confirm: ", res);
+
+      return {
+        status: "success",
+        message: "canceled token stream.",
+        data: {
+          ...res,
+        },
+      };
+    } catch (e) {
+      return {
+        status: "error",
+        message: e,
+        data: null,
+      };
     }
+  }
 
-    public async pause(data: any): Promise<any> {
-        const { sender, receiver, pda } = data;
+  public async withdraw(data: any): Promise<any> {
+    const { sender, receiver, token, pda, amount } = data;
+    // console.log("withdraw token stream data: ", data);
 
-        // console.log("pause token stream data: ", data);
+    const senderAddress = new PublicKey(sender);
+    const recipientAddress =
+      receiver instanceof Keypair
+        ? new PublicKey(receiver.publicKey)
+        : new PublicKey(receiver);
+    const tokenMintAddress = new PublicKey(token);
+    const escrowAddress = new PublicKey(pda);
+    const _TOKEN_PROGRAM_ID_ = new PublicKey(_TOKEN_PROGRAM_ID);
+    const _SYSTEM_RENT = new PublicKey(SYSTEM_RENT);
+    const _A_TOKEN = new PublicKey(A_TOKEN);
+    const _FEE_ADDRESS = new PublicKey(FEE_ADDRESS);
 
-        const senderAddress = new PublicKey(sender);
-        const recipientAddress = new PublicKey(receiver);
-        const escrowAddress = new PublicKey(pda);
-        // const tokenMintAddress = new PublicKey(token);
+    const [zebecWalletAddress, _] = await this._findZebecWalletAccount(
+      senderAddress
+    );
+    const recipientAssociatedTokenAddress =
+      await this._findAssociatedTokenAddress(
+        recipientAddress,
+        tokenMintAddress
+      );
+    const zebecWalletAssociatedTokenAddress =
+      await this._findAssociatedTokenAddress(
+        zebecWalletAddress,
+        tokenMintAddress
+      );
+    const feeAssociatedTokenAddress = await this._findAssociatedTokenAddress(
+      _FEE_ADDRESS,
+      tokenMintAddress
+    );
+    const [withdrawEscrowAddress, __] = await this._findWithDrawEscrowAccount(
+      senderAddress,
+      tokenMintAddress
+    );
 
-        const ix = await INSTRUCTIONS.createPauseMultiTokenStreamInstruction(
-            senderAddress,
-            recipientAddress,
-            escrowAddress,
-            this._programId
-        )
+    const ix = await INSTRUCTIONS.createWithdrawMultiTokenStreamInstruction(
+      senderAddress,
+      recipientAddress,
+      zebecWalletAddress,
+      escrowAddress,
+      withdrawEscrowAddress,
+      _TOKEN_PROGRAM_ID_,
+      tokenMintAddress,
+      _SYSTEM_RENT,
+      zebecWalletAssociatedTokenAddress,
+      recipientAssociatedTokenAddress,
+      _A_TOKEN,
+      _FEE_ADDRESS,
+      feeAssociatedTokenAddress,
+      this._programId,
+      amount
+    );
 
-        let tx = new Transaction().add({...ix});
-        const recentHash = await this._connection.getRecentBlockhash();
+    let tx = new Transaction().add({ ...ix });
+    const recentHash = await this._connection.getRecentBlockhash();
 
-        try {
-            tx.recentBlockhash = recentHash.blockhash;
-            tx.feePayer = this.walletProvider.publicKey;
-            
-            // console.log("transaction ix after adding properties: ", tx);
-    
-            const res = await this._signAndConfirm(tx);
+    try {
+      tx.recentBlockhash = recentHash.blockhash;
+      tx.feePayer = this.walletProvider.publicKey;
 
-            // console.log("response from sign and confirm: ", res);
-    
-            return {
-                status: "success",
-                message: "paused token stream.",
-                data: {
-                    ...res
-                }
-            }
-        } catch(e) {
-            return {
-                status: "error",
-                message: e,
-                data: null
-            }
-        }
+      // console.log("transaction ix after adding properties: ", tx);
+      let res;
+      if (receiver instanceof Keypair) {
+        res = await this._signAndConfirm(tx, [receiver]);
+      } else {
+        res = await this._signAndConfirm(tx);
+      }
 
+      // console.log("response from sign and confirm: ", res);
+
+      return {
+        status: "success",
+        message: "withdraw token stream.",
+        data: {
+          ...res,
+        },
+      };
+    } catch (e) {
+      return {
+        status: "error",
+        message: e,
+        data: null,
+      };
     }
+  }
 
-    public async resume(data: any): Promise<any> {
-        const { sender, receiver, pda } = data;
+  public async deposit(data: any): Promise<any> {
+    const { sender, token, amount } = data;
 
-        // console.log("resume token stream data: ", data);
+    // console.log("deposit token stream data: ", data);
 
-        const senderAddress = new PublicKey(sender);
-        const recipientAddress = new PublicKey(receiver);
-        const escrowAddress = new PublicKey(pda);
+    const senderAddress = new PublicKey(sender);
+    const tokenMintAddress = new PublicKey(token);
 
-        const ix = await INSTRUCTIONS.createResumeMultiTokenStreamInstruction(
-            senderAddress,
-            recipientAddress,
-            escrowAddress,
-            this._programId
-        )
+    const senderAssociatedTokenAddress = await this._findAssociatedTokenAddress(
+      senderAddress,
+      tokenMintAddress
+    );
+    const [zebecWalletAddress, _] = await this._findZebecWalletAccount(
+      senderAddress
+    );
+    const zebecWalletAssociatedTokenAddress =
+      await this._findAssociatedTokenAddress(
+        zebecWalletAddress,
+        tokenMintAddress
+      );
+    const _TOKEN_PROGRAM_ID_ = new PublicKey(_TOKEN_PROGRAM_ID);
+    const _SYSTEM_RENT = new PublicKey(SYSTEM_RENT);
+    const _A_TOKEN = new PublicKey(A_TOKEN);
 
-        let tx = new Transaction().add({...ix});
-        const recentHash = await this._connection.getRecentBlockhash();
+    // console.log("Sender Associated Token Address", senderAssociatedTokenAddress);
+    // console.log("Zebec Wallet Associated Token Address", zebecWalletAssociatedTokenAddress);
 
-        try {
-            tx.recentBlockhash = recentHash.blockhash;
-            tx.feePayer = this.walletProvider.publicKey;
-            
-            // console.log("transaction ix after adding properties: ", tx);
-    
-            const res = await this._signAndConfirm(tx);
+    const ix = await INSTRUCTIONS.createDepositMultiTokenInstruction(
+      senderAddress,
+      zebecWalletAddress,
+      _TOKEN_PROGRAM_ID_,
+      tokenMintAddress,
+      _SYSTEM_RENT,
+      senderAssociatedTokenAddress,
+      zebecWalletAssociatedTokenAddress,
+      _A_TOKEN,
+      this._programId,
+      amount
+    );
 
-            // console.log("response from sign and confirm: ", res);
-    
-            return {
-                status: "success",
-                message: "resumed token stream.",
-                data: {
-                    ...res
-                }
-            }
-        } catch(e) {
-            return {
-                status: "error",
-                message: e,
-                data: null
-            }
-        }
+    let tx = new Transaction().add({ ...ix });
+    const recentHash = await this._connection.getRecentBlockhash();
+
+    try {
+      tx.recentBlockhash = recentHash.blockhash;
+      tx.feePayer = this.walletProvider.publicKey;
+
+      // console.log("transaction ix after adding properties: ", tx);
+
+      const res = await this._signAndConfirm(tx);
+
+      // console.log("response from sign and confirm: ", res);
+
+      return {
+        status: "success",
+        message: "deposited token to zebec wallet.",
+        data: {
+          ...res,
+        },
+      };
+    } catch (e) {
+      return {
+        status: "error",
+        message: e,
+        data: null,
+      };
     }
+  }
 
-    public async cancel(data: any): Promise<any> {
-        const { sender, receiver, token, pda} = data;
+  public async withdrawDepositedToken(data: any): Promise<any> {
+    const { sender, token, amount } = data;
 
-        // console.log("cancel token stream data: ", data);
+    // console.log("withdraw deposited token data: ", data);
 
-        const senderAddress = new PublicKey(sender);
-        const recipientAddress = new PublicKey(receiver);
-        const tokenMintAddress = new PublicKey(token);
-        const escrowAddress = new PublicKey(pda);
+    const senderAddress = new PublicKey(sender);
+    const tokenMintAddress = new PublicKey(token);
+    const [zebecWalletAddress, _] = await this._findZebecWalletAccount(
+      senderAddress
+    );
+    const [withdrawEscrowAddress, __] = await this._findWithDrawEscrowAccount(
+      senderAddress,
+      tokenMintAddress
+    );
+    const senderAssociatedTokenAddress = await this._findAssociatedTokenAddress(
+      senderAddress,
+      tokenMintAddress
+    );
+    const zebecWalletAssociatedTokenAddress =
+      await this._findAssociatedTokenAddress(
+        zebecWalletAddress,
+        tokenMintAddress
+      );
+    const _TOKEN_PROGRAM_ID_ = new PublicKey(_TOKEN_PROGRAM_ID);
 
-        const [withdrawEscrowAddress, _] = await this._findWithDrawEscrowAccount(senderAddress, tokenMintAddress);
-        const [zebecWalletAddress, __] = await this._findZebecWalletAccount(senderAddress);
+    const ix = await INSTRUCTIONS.createWithdrawDepositedTokenInstruction(
+      senderAddress,
+      _TOKEN_PROGRAM_ID_,
+      tokenMintAddress,
+      senderAssociatedTokenAddress,
+      zebecWalletAddress,
+      withdrawEscrowAddress,
+      zebecWalletAssociatedTokenAddress,
+      this._programId,
+      amount
+    );
 
-        const recipientAssociatedTokenAddress = await this._findAssociatedTokenAddress(recipientAddress, tokenMintAddress);
-        const zebecWalletAssociatedTokenAddress = await this._findAssociatedTokenAddress(zebecWalletAddress, tokenMintAddress);
-        const feeAssociatedTokenAddress = await this._findAssociatedTokenAddress(new PublicKey(FEE_ADDRESS), tokenMintAddress);
+    let tx = new Transaction().add({ ...ix });
+    const recentHash = await this._connection.getRecentBlockhash();
 
-        const ix = await INSTRUCTIONS.createCancelMultiTokenStreamInstruction(
-            senderAddress,
-            recipientAddress,
-            tokenMintAddress,
-            zebecWalletAddress,
-            escrowAddress,
-            withdrawEscrowAddress,
-            this._programId,
-            recipientAssociatedTokenAddress,
-            zebecWalletAssociatedTokenAddress,
-            feeAssociatedTokenAddress
-        )
+    try {
+      tx.recentBlockhash = recentHash.blockhash;
+      tx.feePayer = this.walletProvider.publicKey;
 
-        let tx = new Transaction().add({...ix});
-        const recentHash = await this._connection.getRecentBlockhash();
+      // console.log("transaction ix after adding properties: ", tx);
 
-        try {
-            tx.recentBlockhash = recentHash.blockhash;
-            tx.feePayer = this.walletProvider.publicKey;
-            
-            // console.log("transaction ix after adding properties: ", tx);
-    
-            const res = await this._signAndConfirm(tx);
+      const res = await this._signAndConfirm(tx);
 
-            // console.log("response from sign and confirm: ", res);
-    
-            return {
-                status: "success",
-                message: "canceled token stream.",
-                data: {
-                    ...res
-                }
-            }
-        } catch(e) {
-            return {
-                status: "error",
-                message: e,
-                data: null
-            }
-        }
+      // console.log("response from sign and confirm: ", res);
 
-
+      return {
+        status: "success",
+        message: "withdrawn token from zebec wallet.",
+        data: {
+          ...res,
+        },
+      };
+    } catch (e) {
+      return {
+        status: "error",
+        message: e,
+        data: null,
+      };
     }
-
-    public async withdraw(data: any): Promise<any> {
-        const { sender, receiver, token, pda, amount } = data;
-        // console.log("withdraw token stream data: ", data);
-
-        const senderAddress = new PublicKey(sender);
-        const recipientAddress = new PublicKey(receiver);
-        const tokenMintAddress = new PublicKey(token);
-        const escrowAddress = new PublicKey(pda);
-        const _TOKEN_PROGRAM_ID_ = new PublicKey(_TOKEN_PROGRAM_ID);
-        const _SYSTEM_RENT = new PublicKey(SYSTEM_RENT);
-        const _A_TOKEN = new PublicKey(A_TOKEN);
-        const _FEE_ADDRESS = new PublicKey(FEE_ADDRESS);
-
-        const [zebecWalletAddress, _] = await this._findZebecWalletAccount(senderAddress);
-        const recipientAssociatedTokenAddress = await this._findAssociatedTokenAddress(recipientAddress, tokenMintAddress);
-        const zebecWalletAssociatedTokenAddress = await this._findAssociatedTokenAddress(zebecWalletAddress, tokenMintAddress);
-        const feeAssociatedTokenAddress = await this._findAssociatedTokenAddress(_FEE_ADDRESS, tokenMintAddress);
-        const [withdrawEscrowAddress, __] = await this._findWithDrawEscrowAccount(senderAddress, tokenMintAddress);
-
-        const ix = await INSTRUCTIONS.createWithdrawMultiTokenStreamInstruction(
-            senderAddress,
-            recipientAddress,
-            zebecWalletAddress,
-            escrowAddress,
-            withdrawEscrowAddress,
-            _TOKEN_PROGRAM_ID_,
-            tokenMintAddress,
-            _SYSTEM_RENT,
-            zebecWalletAssociatedTokenAddress,
-            recipientAssociatedTokenAddress,
-            _A_TOKEN,
-            _FEE_ADDRESS,
-            feeAssociatedTokenAddress,
-            this._programId,
-            amount
-        )
-
-        let tx = new Transaction().add({...ix});
-        const recentHash = await this._connection.getRecentBlockhash();
-
-        try {
-            tx.recentBlockhash = recentHash.blockhash;
-            tx.feePayer = this.walletProvider.publicKey;
-            
-            // console.log("transaction ix after adding properties: ", tx);
-    
-            const res = await this._signAndConfirm(tx);
-
-            // console.log("response from sign and confirm: ", res);
-    
-            return {
-                status: "success",
-                message: "withdraw token stream.",
-                data: {
-                    ...res
-                }
-            }
-        } catch(e) {
-            return {
-                status: "error",
-                message: e,
-                data: null
-            }
-        }
-
-    }
-
-    public async deposit(data: any): Promise<any> {
-        const { sender, token, amount } = data;
-
-        // console.log("deposit token stream data: ", data);
-
-        const senderAddress = new PublicKey(sender);
-        const tokenMintAddress = new PublicKey(token);
-
-        const senderAssociatedTokenAddress = await this._findAssociatedTokenAddress(senderAddress, tokenMintAddress);
-        const [zebecWalletAddress, _] = await this._findZebecWalletAccount(senderAddress);
-        const zebecWalletAssociatedTokenAddress = await this._findAssociatedTokenAddress(zebecWalletAddress, tokenMintAddress);
-        const _TOKEN_PROGRAM_ID_ = new PublicKey(_TOKEN_PROGRAM_ID);
-        const _SYSTEM_RENT = new PublicKey(SYSTEM_RENT);
-        const _A_TOKEN = new PublicKey(A_TOKEN);
-
-        // console.log("Sender Associated Token Address", senderAssociatedTokenAddress);
-        // console.log("Zebec Wallet Associated Token Address", zebecWalletAssociatedTokenAddress);
-
-        const ix = await INSTRUCTIONS.createDepositMultiTokenInstruction(
-            senderAddress,
-            zebecWalletAddress,
-            _TOKEN_PROGRAM_ID_,
-            tokenMintAddress,
-            _SYSTEM_RENT,
-            senderAssociatedTokenAddress,
-            zebecWalletAssociatedTokenAddress,
-            _A_TOKEN,
-            this._programId,
-            amount
-        )
-
-        let tx = new Transaction().add({...ix});
-        const recentHash = await this._connection.getRecentBlockhash();
-
-        try {
-            tx.recentBlockhash = recentHash.blockhash;
-            tx.feePayer = this.walletProvider.publicKey;
-            
-            // console.log("transaction ix after adding properties: ", tx);
-    
-            const res = await this._signAndConfirm(tx);
-
-            // console.log("response from sign and confirm: ", res);
-    
-            return {
-                status: "success",
-                message: "deposited token to zebec wallet.",
-                data: {
-                    ...res
-                }
-            }
-        } catch(e) {
-            return {
-                status: "error",
-                message: e,
-                data: null
-            }
-        }
-    }
-
-    public async withdrawDepositedToken(data: any): Promise<any> {
-        const { sender, token, amount } = data;
-
-        // console.log("withdraw deposited token data: ", data);
-
-        const senderAddress = new PublicKey(sender);
-        const tokenMintAddress = new PublicKey(token);
-        const [zebecWalletAddress, _] = await this._findZebecWalletAccount(senderAddress);
-        const [withdrawEscrowAddress, __] = await this._findWithDrawEscrowAccount(senderAddress, tokenMintAddress);
-        const senderAssociatedTokenAddress = await this._findAssociatedTokenAddress(senderAddress, tokenMintAddress);
-        const zebecWalletAssociatedTokenAddress = await this._findAssociatedTokenAddress(zebecWalletAddress, tokenMintAddress);
-        const _TOKEN_PROGRAM_ID_ = new PublicKey(_TOKEN_PROGRAM_ID);
-
-        const ix = await INSTRUCTIONS.createWithdrawDepositedTokenInstruction(
-            senderAddress,
-            _TOKEN_PROGRAM_ID_,
-            tokenMintAddress,
-            senderAssociatedTokenAddress,
-            zebecWalletAddress,
-            withdrawEscrowAddress,
-            zebecWalletAssociatedTokenAddress,
-            this._programId,
-            amount
-        )
-
-        let tx = new Transaction().add({...ix});
-        const recentHash = await this._connection.getRecentBlockhash();
-
-        try {
-            tx.recentBlockhash = recentHash.blockhash;
-            tx.feePayer = this.walletProvider.publicKey;
-            
-            // console.log("transaction ix after adding properties: ", tx);
-    
-            const res = await this._signAndConfirm(tx);
-
-            // console.log("response from sign and confirm: ", res);
-    
-            return {
-                status: "success",
-                message: "withdrawn token from zebec wallet.",
-                data: {
-                    ...res
-                }
-            }
-        } catch(e) {
-            return {
-                status: "error",
-                message: e,
-                data: null
-            }
-        }
-
-    }
+  }
 }

--- a/packages/stream/src/types.ts
+++ b/packages/stream/src/types.ts
@@ -1,36 +1,38 @@
+import { Keypair } from "@solana/web3.js";
+
 export type SignAndConfirm = {
-    transactionHash: string;
-    pda?: string;
-}
+  transactionHash: string;
+  pda?: string;
+};
 
 export type StreamTransactionResponse = {
-    status: string;
-    message: string | Error;
-    data: SignAndConfirm
-}
+  status: string;
+  message: string | Error;
+  data: SignAndConfirm;
+};
 
 export type InitNativeStream = {
-    sender: string;
-    receiver: string;
-    start_time: number;
-    end_time: number;
-    amount: number;
-}
+  sender: string;
+  receiver: string;
+  start_time: number;
+  end_time: number;
+  amount: number;
+};
 
 export type PauseResumeCancelNativeStream = {
-    sender: string;
-    receiver: string;
-    pda: string;
-}
+  sender: string;
+  receiver: string;
+  pda: string;
+};
 
 export type WithdrawNativeStream = {
-    sender: string;
-    receiver: string;
-    pda: string;
-    amount: number;
-}
+  sender: string;
+  receiver: string | Keypair;
+  pda: string;
+  amount: number;
+};
 
 export type DepositWithdrawSol = {
-    sender: string;
-    amount: number;
-}
+  sender: string;
+  amount: number;
+};


### PR DESCRIPTION
1. Change the _signAndConfirm function as to add the parameters of signers and if wallet provider is the instance of keypair then sign the transaction differently as in the code. I passed the arguments of signers into the init (native and spl) and withdraw as this need the signers to sign the transaction other than sender.
2. change the receiver type of WithdrawNativeStream